### PR TITLE
Read maxSR as a value rather than as an unevaluated expression

### DIFF
--- a/R/optimize.portfolio.R
+++ b/R/optimize.portfolio.R
@@ -1206,7 +1206,7 @@ optimize.portfolio <- optimize.portfolio_v2 <- function(
         }
       } else {
         # if(hasArg(ef)) ef=match.call(expand.dots=TRUE)$ef else ef=FALSE
-        if (hasArg(maxSR)) maxSR <- match.call(expand.dots = TRUE)$maxSR else maxSR <- FALSE
+        maxSR <- isTRUE(list(...)$maxSR)
         if (maxSR) {
           target <- max_sr_opt(R = R, constraints = constraints, moments = moments, lambda_hhi = lambda_hhi, conc_groups = conc_groups, solver = solver, control = control)
           # need to set moments$mean=0 here because quadratic utility and target return is sensitive to returning no solution
@@ -3019,7 +3019,7 @@ optimize.portfolio <- optimize.portfolio_v2 <- function(
       tmpname <- "HHI"
     } else if (reward & risk & !risk_ES & !risk_CSM & !risk_HHI & !risk_EQS) {
       # mean-var/sharpe ratio
-      if (hasArg(maxSR)) maxSR <- match.call(expand.dots = TRUE)$maxSR
+      maxSR <- isTRUE(list(...)$maxSR)
 
       if (!maxSR) {
         # min mean-variance

--- a/tests/testthat/test-max-sharpe.R
+++ b/tests/testthat/test-max-sharpe.R
@@ -85,3 +85,45 @@ test_that("maxSR.lo.DE objective measure mean is numeric", {
 test_that("maxSR.lo.DE objective measure StdDev is numeric", {
   expect_true(is.numeric(extractObjectiveMeasures(maxSR.lo.DE)$StdDev))
 })
+
+# --- maxSR must be read as a value, not as an expression --------------------
+#
+# maxSR arrives through `...` and was recovered with
+# match.call(expand.dots = TRUE)$maxSR, which yields the unevaluated
+# expression.  A literal TRUE happens to work; anything else does not.
+# `if (maxSR)` on a symbol raises "argument is not interpretable as logical",
+# so driving maxSR from a variable -- what a loop or a backtest does -- failed.
+
+sr.portf <- add.objective(
+  add.objective(
+    add.constraint(
+      add.constraint(portfolio.spec(assets = funds), type = "full_investment"),
+      type = "long_only"),
+    type = "return", name = "mean"),
+  type = "risk", name = "StdDev")
+
+test_that("maxSR accepts a variable, not only a literal TRUE", {
+  flag <- TRUE
+  lit <- optimize.portfolio(R = R, portfolio = sr.portf,
+                            optimize_method = "ROI", maxSR = TRUE, trace = TRUE)
+  var <- optimize.portfolio(R = R, portfolio = sr.portf,
+                            optimize_method = "ROI", maxSR = flag, trace = TRUE)
+  expect_equal(as.numeric(var$weights), as.numeric(lit$weights), tolerance = 1e-10)
+})
+
+test_that("maxSR accepts an expression that evaluates to TRUE", {
+  opt <- optimize.portfolio(R = R, portfolio = sr.portf, optimize_method = "ROI",
+                            maxSR = isTRUE(TRUE), trace = TRUE)
+  ref <- optimize.portfolio(R = R, portfolio = sr.portf, optimize_method = "ROI",
+                            maxSR = TRUE, trace = TRUE)
+  expect_equal(as.numeric(opt$weights), as.numeric(ref$weights), tolerance = 1e-10)
+})
+
+test_that("a maxSR variable holding FALSE is not read as TRUE", {
+  flag <- FALSE
+  off <- optimize.portfolio(R = R, portfolio = sr.portf,
+                            optimize_method = "ROI", maxSR = flag, trace = TRUE)
+  ref <- optimize.portfolio(R = R, portfolio = sr.portf,
+                            optimize_method = "ROI", maxSR = FALSE, trace = TRUE)
+  expect_equal(as.numeric(off$weights), as.numeric(ref$weights), tolerance = 1e-10)
+})


### PR DESCRIPTION
`maxSR` arrives through `...` and is recovered with

```r
if (hasArg(maxSR)) maxSR <- match.call(expand.dots = TRUE)$maxSR else maxSR <- FALSE
```

`match.call()` yields the expression, not the value. A literal `TRUE` happens to
work because `if (TRUE)` is fine. Anything else is not:

```r
library(PortfolioAnalytics)
data(edhec)
R <- edhec[, 1:8]
p <- portfolio.spec(colnames(R)) |>
  add.constraint("full_investment") |> add.constraint("long_only") |>
  add.objective(type = "return", name = "mean") |>
  add.objective(type = "risk",   name = "StdDev")

flag <- TRUE
optimize.portfolio(R, p, optimize_method = "ROI", maxSR = flag)
#> Error in if (maxSR) { : argument is not interpretable as logical
```

`if (maxSR)` is being applied to a symbol. Driving `maxSR` from a variable, which
is what a loop or a rolling backtest does, fails outright.

Both sites now read it from `...`, where it has already been evaluated:

```r
maxSR <- isTRUE(list(...)$maxSR)
```

`isTRUE()` keeps a missing or non-logical value falsy, which is the previous
behaviour for those cases.

### Tests

Three new tests in `tests/testthat/test-max-sharpe.R`, comparing a literal, a
variable and an expression against each other, plus a check that a variable
holding `FALSE` is not read as `TRUE`. All are new; **no existing test is
modified**.

Measured, running that file against both builds:

| | PASS | ERROR |
|---|---:|---:|
| `master` | 8 | 3 |
| this branch | 11 | 0 |

### Scope

Two files, 44 insertions, 2 deletions. This change stands on its own and does
not depend on any other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
