### PR TITLE
Fix maxSR discarding the expected returns supplied through momentFUN

### DIFF
--- a/R/optFUN.R
+++ b/R/optFUN.R
@@ -14,8 +14,15 @@
 #' @param conc_groups list of vectors specifying the groups of the assets.
 #' @param solver solver to use
 #' @param control list of solver control parameters
+#' @param target_mean optional vector of expected returns used to impose the
+#' target return constraint. This is required when the linear term of the
+#' quadratic objective is deliberately zeroed out (as the maximum Sharpe Ratio
+#' solver does) but the target return must still be imposed with the expected
+#' returns that the target was derived from. If \code{NULL} (the default) the
+#' expected returns in \code{moments$mean} are used, falling back to the sample
+#' column means of \code{R} when \code{moments$mean} is all zero.
 #' @author Ross Bennett
-gmv_opt <- function(R, constraints, moments, lambda, target, lambda_hhi, conc_groups, solver="quadprog", control=NULL){
+gmv_opt <- function(R, constraints, moments, lambda, target, lambda_hhi, conc_groups, solver="quadprog", control=NULL, target_mean=NULL){
   if (!"package:ROI" %in% search() && !requireNamespace("ROI", quietly = TRUE))
     stop("Package 'ROI' is required but not installed. ",
          "Install it with: install.packages('ROI')", call. = FALSE)
@@ -32,8 +39,14 @@ gmv_opt <- function(R, constraints, moments, lambda, target, lambda_hhi, conc_gr
   
   # Check for a target return constraint
   if(!is.na(target)) {
-    # If var is the only objective specified, then moments$mean won't be calculated
-    if(all(moments$mean==0)){
+    if(!is.null(target_mean)){
+      # The caller has zeroed out moments$mean for the objective function, but
+      # the target return must still be imposed with the expected returns the
+      # target was derived from. Otherwise the target is picked on one frontier
+      # and imposed on another.
+      tmp_means <- target_mean
+    } else if(all(moments$mean==0)){
+      # If var is the only objective specified, then moments$mean won't be calculated
       tmp_means <- colMeans(R)
     } else {
       tmp_means <- moments$mean

--- a/R/optFUN.R
+++ b/R/optFUN.R
@@ -47,11 +47,25 @@ gmv_opt <- function(R, constraints, moments, lambda, target, lambda_hhi, conc_gr
   rhs.vec <- target
   meq <- 1
   
-  # Set up initial A matrix for leverage constraints
-  Amat <- rbind(Amat, rep(1, N), rep(-1, N))
-  dir.vec <- c(dir.vec, ">=",">=")
-  rhs.vec <- c(rhs.vec, constraints$min_sum, -constraints$max_sum)
-  
+  # Set up initial A matrix for leverage constraints.
+  # If min_sum == max_sum (e.g. a full investment constraint) the two
+  # inequality rows are always simultaneously active and linearly dependent.
+  # That makes the active set rank deficient and quadprog fails with
+  # "constraints are inconsistent, no solution!" for many right hand sides,
+  # in which case ROI returns a vector of NA weights. Encoding the leverage
+  # constraint as a single equality row avoids the degeneracy.
+  if(!is.null(constraints$min_sum) && !is.null(constraints$max_sum) &&
+     is.finite(constraints$min_sum) && is.finite(constraints$max_sum) &&
+     isTRUE(all.equal(constraints$min_sum, constraints$max_sum))){
+    Amat <- rbind(Amat, rep(1, N))
+    dir.vec <- c(dir.vec, "==")
+    rhs.vec <- c(rhs.vec, constraints$max_sum)
+  } else {
+    Amat <- rbind(Amat, rep(1, N), rep(-1, N))
+    dir.vec <- c(dir.vec, ">=",">=")
+    rhs.vec <- c(rhs.vec, constraints$min_sum, -constraints$max_sum)
+  }
+
   # Add min box constraints
   Amat <- rbind(Amat, diag(N))
   dir.vec <- c(dir.vec, rep(">=", N))

--- a/R/optFUN.R
+++ b/R/optFUN.R
@@ -69,7 +69,7 @@ gmv_opt <- function(R, constraints, moments, lambda, target, lambda_hhi, conc_gr
   # constraint as a single equality row avoids the degeneracy.
   if(!is.null(constraints$min_sum) && !is.null(constraints$max_sum) &&
      is.finite(constraints$min_sum) && is.finite(constraints$max_sum) &&
-     isTRUE(all.equal(constraints$min_sum, constraints$max_sum))){
+     isTRUE(constraints$min_sum == constraints$max_sum)){
     Amat <- rbind(Amat, rep(1, N))
     dir.vec <- c(dir.vec, "==")
     rhs.vec <- c(rhs.vec, constraints$max_sum)

--- a/R/optFUN.R
+++ b/R/optFUN.R
@@ -40,6 +40,15 @@ gmv_opt <- function(R, constraints, moments, lambda, target, lambda_hhi, conc_gr
   # Check for a target return constraint
   if(!is.na(target)) {
     if(!is.null(target_mean)){
+      # gmv_opt() is internal, but target_mean feeds straight into the
+      # constraint matrix, where a wrong length would be recycled and a
+      # non-numeric coerced. Either way the target return constraint would
+      # be silently wrong, which is the failure mode this argument exists
+      # to remove.
+      if(!is.numeric(target_mean) || length(target_mean) != N)
+        stop(sprintf(paste("target_mean must be a numeric vector with one entry per asset:",
+                           "got %s of length %d, expected length %d"),
+                     class(target_mean)[1], length(target_mean), N))
       # The caller has zeroed out moments$mean for the objective function, but
       # the target return must still be imposed with the expected returns the
       # target was derived from. Otherwise the target is picked on one frontier

--- a/R/optimize.portfolio.R
+++ b/R/optimize.portfolio.R
@@ -1207,13 +1207,20 @@ optimize.portfolio <- optimize.portfolio_v2 <- function(
       } else {
         # if(hasArg(ef)) ef=match.call(expand.dots=TRUE)$ef else ef=FALSE
         if (hasArg(maxSR)) maxSR <- match.call(expand.dots = TRUE)$maxSR else maxSR <- FALSE
+        target_mean <- NULL
         if (maxSR) {
           target <- max_sr_opt(R = R, constraints = constraints, moments = moments, lambda_hhi = lambda_hhi, conc_groups = conc_groups, solver = solver, control = control)
           # need to set moments$mean=0 here because quadratic utility and target return is sensitive to returning no solution
           tmp_moments_mean <- moments$mean
           moments$mean <- rep(0, length(moments$mean))
+          # target was computed from tmp_moments_mean, so the target return
+          # constraint has to be imposed with those same expected returns.
+          # Without this, gmv_opt() sees an all-zero moments$mean and falls
+          # back to colMeans(R), which differs from tmp_moments_mean whenever
+          # momentFUN supplies estimated (e.g. excess return) means.
+          target_mean <- tmp_moments_mean
         }
-        roi_result <- gmv_opt(R = R, constraints = constraints, moments = moments, lambda = lambda, target = target, lambda_hhi = lambda_hhi, conc_groups = conc_groups, solver = solver, control = control)
+        roi_result <- gmv_opt(R = R, constraints = constraints, moments = moments, lambda = lambda, target = target, lambda_hhi = lambda_hhi, conc_groups = conc_groups, solver = solver, control = control, target_mean = target_mean)
         weights <- roi_result$weights
         # obj_vals <- constrained_objective(w=weights, R=R, portfolio, trace=TRUE, normalize=FALSE)$objective_measures
         obj_vals <- roi_result$obj_vals

--- a/man/gmv_opt.Rd
+++ b/man/gmv_opt.Rd
@@ -13,7 +13,8 @@ gmv_opt(
   lambda_hhi,
   conc_groups,
   solver = "quadprog",
-  control = NULL
+  control = NULL,
+  target_mean = NULL
 )
 }
 \arguments{
@@ -34,6 +35,14 @@ gmv_opt(
 \item{solver}{solver to use}
 
 \item{control}{list of solver control parameters}
+
+\item{target_mean}{optional vector of expected returns used to impose the
+target return constraint. This is required when the linear term of the
+quadratic objective is deliberately zeroed out (as the maximum Sharpe Ratio
+solver does) but the target return must still be imposed with the expected
+returns that the target was derived from. If \code{NULL} (the default) the
+expected returns in \code{moments$mean} are used, falling back to the sample
+column means of \code{R} when \code{moments$mean} is all zero.}
 }
 \description{
 This function is called by optimize.portfolio to solve minimum variance or 

--- a/tests/testthat/test-max-sharpe.R
+++ b/tests/testthat/test-max-sharpe.R
@@ -85,3 +85,52 @@ test_that("maxSR.lo.DE objective measure mean is numeric", {
 test_that("maxSR.lo.DE objective measure StdDev is numeric", {
   expect_true(is.numeric(extractObjectiveMeasures(maxSR.lo.DE)$StdDev))
 })
+
+# --- An exact full investment constraint must not be degenerate -------------
+#
+# gmv_opt() used to encode min_sum == max_sum as two opposing inequality rows
+# (sum(w) >= 1 and -sum(w) >= -1).  Both are always active and linearly
+# dependent, which makes quadprog's active set rank deficient; it then fails
+# with "constraints are inconsistent, no solution!" on problems whose entire
+# constraint set is sum(w) = 1 and 0 <= w <= 1.  ROI does not propagate that
+# error, it returns a solution of NAs, so optimize.portfolio silently produced
+# an all-NA weight vector.
+
+test_that("exact full investment solves and matches quadprog (min variance)", {
+  Rw <- edhec[3:20, ]  # 18 months, 13 series: a window that used to fail
+  fi.portf <- add.objective(
+    add.constraint(add.constraint(portfolio.spec(assets = colnames(Rw)),
+                                  type = "full_investment"),
+                   type = "long_only"),
+    type = "risk", name = "var")
+  cn <- PortfolioAnalytics:::get_constraints(fi.portf)
+  expect_equal(cn$min_sum, cn$max_sum)
+
+  opt <- optimize.portfolio(R = Rw, portfolio = fi.portf, optimize_method = "ROI")
+  w <- as.numeric(extractWeights(opt))
+  expect_false(anyNA(w))
+  expect_equal(sum(w), 1, tolerance = 1e-8)
+  expect_gte(min(w), -1e-8)
+
+  N <- ncol(Rw)
+  ref <- quadprog::solve.QP(
+    Dmat = 2 * cov(Rw), dvec = rep(0, N),
+    Amat = cbind(rep(1, N), diag(N)), bvec = c(1, rep(0, N)), meq = 1)$solution
+  expect_equal(w, ref, tolerance = 1e-6)
+})
+
+test_that("exact full investment solves on every rolling window it used to fail on", {
+  win <- 18L
+  fi.portf <- add.objective(
+    add.constraint(add.constraint(portfolio.spec(assets = colnames(edhec)),
+                                  type = "full_investment"),
+                   type = "long_only"),
+    type = "risk", name = "var")
+  starts <- seq(1L, 80L, by = 1L)
+  bad <- vapply(starts, function(i) {
+    o <- try(optimize.portfolio(R = edhec[i:(i + win - 1L), ], portfolio = fi.portf,
+                                optimize_method = "ROI"), silent = TRUE)
+    inherits(o, "try-error") || anyNA(extractWeights(o))
+  }, logical(1))
+  expect_equal(sum(bad), 0L)
+})

--- a/tests/testthat/test-max-sharpe.R
+++ b/tests/testthat/test-max-sharpe.R
@@ -86,6 +86,119 @@ test_that("maxSR.lo.DE objective measure StdDev is numeric", {
   expect_true(is.numeric(extractObjectiveMeasures(maxSR.lo.DE)$StdDev))
 })
 
+# --- Correctness tests: maxSR must return the tangency portfolio ----------
+#
+# These are correctness tests, not regression tests.  The portfolio returned
+# by maxSR=TRUE is compared against
+#   (a) the analytic long-only tangency portfolio, and
+#   (b) every point of the long-only mean-variance frontier,
+# both solved independently with quadprog.  They are run for the plain call
+# (moments come from colMeans(R)) and for a momentFUN that supplies excess
+# return moments, which is the only way to give the ROI maxSR path a
+# non-zero risk-free rate.
+
+skip_if_not_installed("quadprog")
+
+# Analytic long-only tangency portfolio:
+#   min w'Sw  s.t.  mu'w = 1, w >= 0,  then rescale so that sum(w) = 1.
+lo_tangency <- function(mu, sigma) {
+  N <- length(mu)
+  sol <- quadprog::solve.QP(
+    Dmat = 2 * sigma, dvec = rep(0, N),
+    Amat = cbind(mu, diag(N)), bvec = c(1, rep(0, N)), meq = 1
+  )
+  w <- sol$solution / sum(sol$solution)
+  names(w) <- names(mu)
+  w
+}
+
+# Highest Sharpe ratio attainable on the long-only, fully invested
+# mean-variance frontier, solved on a grid of target returns.
+lo_frontier_max_sr <- function(mu, sigma, n = 200) {
+  N <- length(mu)
+  targets <- seq(min(mu), max(mu), length.out = n + 2)
+  targets <- targets[-c(1, n + 2)]
+  srs <- vapply(targets, function(tg) {
+    sol <- try(quadprog::solve.QP(
+      Dmat = 2 * sigma, dvec = rep(0, N),
+      Amat = cbind(mu, rep(1, N), diag(N)),
+      bvec = c(tg, 1, rep(0, N)), meq = 2
+    ), silent = TRUE)
+    if (inherits(sol, "try-error")) return(NA_real_)
+    w <- sol$solution
+    sum(w * mu) / sqrt(sum(crossprod(w, sigma) * w))
+  }, numeric(1))
+  max(srs, na.rm = TRUE)
+}
+
+port_sr <- function(w, mu, sigma) {
+  sum(w * mu) / sqrt(sum(crossprod(w, sigma) * w))
+}
+
+mv.portf <- portfolio.spec(assets = funds)
+mv.portf <- add.constraint(portfolio = mv.portf, type = "full_investment")
+mv.portf <- add.constraint(portfolio = mv.portf, type = "long_only")
+mv.portf <- add.objective(portfolio = mv.portf, type = "return", name = "mean")
+mv.portf <- add.objective(portfolio = mv.portf, type = "risk", name = "StdDev")
+
+sample.mu <- colMeans(R)
+sample.sigma <- cov(R)
+
+test_that("maxSR without momentFUN returns the long-only tangency portfolio", {
+  opt <- optimize.portfolio(
+    R = R, portfolio = mv.portf,
+    optimize_method = "ROI", maxSR = TRUE, trace = TRUE
+  )
+  w <- opt$weights
+  expect_false(anyNA(w))
+  expect_equal(sum(w), 1, tolerance = 1e-6)
+
+  w.tan <- lo_tangency(sample.mu, sample.sigma)
+  expect_equal(as.numeric(w), as.numeric(w.tan), tolerance = 1e-4)
+
+  sr.opt <- port_sr(w, sample.mu, sample.sigma)
+  expect_gte(sr.opt, lo_frontier_max_sr(sample.mu, sample.sigma) - 1e-6)
+})
+
+# A momentFUN supplying excess-return moments must be honoured by every stage
+# of the maxSR solve.  Two risk-free rates are used: 0.001 previously returned
+# a feasible but badly sub-optimal portfolio, 0.0025 previously returned NA
+# weights without any warning.
+for (rf in c(0.001, 0.0025)) {
+  local({
+    rf.local <- rf
+    excess.mu <- sample.mu - rf.local
+    moment.fun <- function(R, portfolio, ...) {
+      list(mu = colMeans(R) - rf.local, sigma = cov(R))
+    }
+
+    test_that(paste0("maxSR with excess-return momentFUN (rf = ", rf.local,
+                     ") returns the long-only tangency portfolio"), {
+      opt <- optimize.portfolio(
+        R = R, portfolio = mv.portf,
+        optimize_method = "ROI", maxSR = TRUE,
+        momentFUN = moment.fun, trace = TRUE
+      )
+      w <- opt$weights
+      expect_false(anyNA(w))
+      expect_equal(sum(w), 1, tolerance = 1e-6)
+
+      w.tan <- lo_tangency(excess.mu, sample.sigma)
+      expect_equal(as.numeric(w), as.numeric(w.tan), tolerance = 1e-4)
+
+      sr.opt <- port_sr(w, excess.mu, sample.sigma)
+      expect_gte(sr.opt, lo_frontier_max_sr(excess.mu, sample.sigma) - 1e-6)
+
+      # the reported mean must be the excess mean supplied by momentFUN
+      expect_equal(
+        as.numeric(extractObjectiveMeasures(opt)$mean),
+        sum(w * excess.mu),
+        tolerance = 1e-8
+      )
+    })
+  })
+}
+
 # --- An exact full investment constraint must not be degenerate -------------
 #
 # gmv_opt() used to encode min_sum == max_sum as two opposing inequality rows

--- a/tests/testthat/test-max-sharpe.R
+++ b/tests/testthat/test-max-sharpe.R
@@ -144,6 +144,20 @@ mv.portf <- add.objective(portfolio = mv.portf, type = "risk", name = "StdDev")
 sample.mu <- colMeans(R)
 sample.sigma <- cov(R)
 
+test_that("gmv_opt rejects a target_mean of the wrong type or length", {
+  cn <- PortfolioAnalytics:::get_constraints(mv.portf)
+  m  <- list(mean = sample.mu, var = sample.sigma)
+  call_it <- function(tm) PortfolioAnalytics:::gmv_opt(
+    R = R, constraints = cn, moments = m, lambda = 1,
+    target = as.numeric(sample.mu %*% rep(1 / length(funds), length(funds))),
+    lambda_hhi = NULL, conc_groups = NULL, solver = "quadprog",
+    target_mean = tm)
+
+  expect_error(call_it(sample.mu[1:2]), "one entry per asset")
+  expect_error(call_it(as.character(sample.mu)), "one entry per asset")
+  expect_no_error(call_it(sample.mu))
+})
+
 test_that("maxSR without momentFUN returns the long-only tangency portfolio", {
   opt <- optimize.portfolio(
     R = R, portfolio = mv.portf,


### PR DESCRIPTION
`maxSR = TRUE` on the ROI path can return a portfolio that is not the maximum
Sharpe ratio portfolio, without any indication that something went wrong.

`max_sr_opt()` derives a target return from `moments$mean`. `optimize.portfolio()`
then zeroes `moments$mean`, deliberately, so that the objective handed to
`gmv_opt()` is pure variance. `gmv_opt()` sees an all-zero mean vector, concludes
the means were never computed, and falls back to `colMeans(R)` when it imposes
the target return constraint:

```r
if (all(moments$mean == 0)) {
  tmp_means <- colMeans(R)
} else {
  tmp_means <- moments$mean
}
```

So the target is chosen on one frontier and imposed on another, whenever
`momentFUN` supplies means that differ from the sample column means: excess
returns, shrinkage estimators, a factor model, Black-Litterman. With the default
`set.portfolio.moments` the two coincide, which is why this has not surfaced.

`gmv_opt()` gains `target_mean`, defaulting to `NULL`. Every existing caller is
unaffected.

### Reproduction

Using the package's own `edhec` data:

```r
library(PortfolioAnalytics)
data(edhec)
R  <- edhec[, 1:8]
rf <- 0.02 / 12

# A momentFUN that supplies excess-return means -- the normal way to get a
# tangency portfolio relative to a risk-free rate.
excess_moments <- function(R, portfolio) {
  list(mu = colMeans(R) - rf, sigma = cov(R),
       m3 = NULL, m4 = NULL, mean = colMeans(R) - rf, var = cov(R))
}

p <- portfolio.spec(colnames(R)) |>
  add.constraint("full_investment") |> add.constraint("long_only") |>
  add.objective(type = "return", name = "mean") |>
  add.objective(type = "risk",   name = "StdDev")

opt <- optimize.portfolio(R, p, optimize_method = "ROI", maxSR = TRUE,
                          momentFUN = "excess_moments")
w   <- extractWeights(opt)
(sum(w * (colMeans(R) - rf))) / sqrt(as.numeric(t(w) %*% cov(R) %*% w))

# What is actually attainable, read off the long-only frontier:
ef <- create.EfficientFrontier(R, p, type = "mean-StdDev", n.portfolios = 300)
fr <- as.data.frame(unclass(ef$frontier))
max((fr$mean - rf) / fr$StdDev)
```

|                             | Sharpe ratio |
|-----------------------------|-------------:|
| `maxSR = TRUE` on `master`  |    0.3498043 |
| best point on the frontier  |    0.3549758 |
| `maxSR = TRUE` with this PR |    0.3549760 |

The returned portfolio is feasible and looks reasonable, so nothing signals that
the objective was missed. With the fix, `maxSR` lands on the best frontier point
to six decimal places.

### Why it depends on the other pull request

`max_sr_opt()` solves its own quadratic programs while scanning for the target,
and those hit the degenerate `min_sum == max_sum` encoding that the
exact-full-investment PR removes. At some risk-free rates the scan therefore
fails and returns a poor target, so this fix alone is not sufficient. Measured on
the same test file:

| code | PASS | FAIL |
|---|---:|---:|
| `master` | 17 | 11 |
| exact-full-investment alone | 20 | 8 |
| both together (this branch) | 28 | 0 |

Each fix is necessary and neither is sufficient by itself.

### Tests

The tests solve their reference portfolio independently -- the analytic long-only
tangency from `quadprog`, and the best point of the long-only frontier on a grid
of target returns -- rather than pinning what this code produces. They are run
for the plain call and for an excess-return `momentFUN` at two risk-free rates.

All are new; **no existing test is modified**. The existing pinned values in that
file (`mean = 0.004357475`, `StdDev = 0.007726142`) are untouched and still pass.

### Scope

Four files, 239 insertions, 11 deletions across the two commits that are not
already in #55, most of it tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
